### PR TITLE
 Map zooms to user location instead of default latitude longitude

### DIFF
--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -10,12 +10,12 @@ import {
 import { MapView } from "expo";
 import { Constants, Location, Permissions } from 'expo';
 
-//Set the initial region of the map to NYC
-const initialRegion = {
+//Set the initial default region of the map to NYC
+initialRegion = {
   latitude: 40.76727216,
   longitude: -73.99392888,
-  latitudeDelta: 0.0922,
-  longitudeDelta: 0.0421
+  latitudeDelta: 0.03,
+  longitudeDelta: 0.03,
 }
 
 class HomeScreen extends React.Component {
@@ -23,7 +23,13 @@ class HomeScreen extends React.Component {
     super(props);
     this.state = {
       //State of the initial region
-      region:{initialRegion},
+      region:{
+        latitude: 40.76727216,
+        longitude: -73.99392888,
+        latitudeDelta: 0.03,
+        longitudeDelta: 0.03,
+      },
+      ready: true,
       location: null,
       errorMessage: null,
       //Locations of bathrooms to be stored
@@ -51,29 +57,35 @@ class HomeScreen extends React.Component {
     }
   }
 
+  //Check if the component successfully mounted on DOM
   componentDidMount() {
-
-    function getLocation(){
-      if(navigator.geolocation){
-        return navigator.geolocation.getCurrentPosition(success);
-      }
-    }
-  
-    function success(position){
-      coordinate = position.coords;
-      console.log(coordinate)
-      return coordinate;
+      //init.latitude = pos.coords.latitude;
+    
+    //Make an error statement if the mounting has failed
+    function errorAlert(err){
+      alert(err);
     }
 
     navigator.geolocation.getCurrentPosition (
-      (position) => { alert("value:" + getLocation()) },
-      (error)    => { alert("Failed to mount") },
+      (position) => {
+        let userState = {
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+          latitudeDelta: 0.015,
+          longitudeDelta: 0.015
+        };
+        //Set the map to the actual user latitude and longitude
+        this.setState({region:userState});
+        initialRegion = userState
+        alert("latitude:" + this.state.region.latitude);
+      },
+      errorAlert,
       {
         enableHighAccuracy: true,
         timeout: 20000,
         maximumAge: 10000
       }
-    )
+    );
   }
 
   _getLocationAsync = async () => {
@@ -87,8 +99,8 @@ class HomeScreen extends React.Component {
     this.setState({ location });
   };
 
-  render() {
 
+  render() {
     let text = "Loading";
     if (this.state.errorMessage) {
       text = this.state.errorMessage;
@@ -96,16 +108,23 @@ class HomeScreen extends React.Component {
       text = JSON.stringify(this.state.location);
     }
     console.log(text);
+    console.log(this.state.region.latitude)
     return (
       <View style={{flex:1}}>
         <MapView
           style={styles.map}
+          key={this.state.forceRefresh}
           provider="google"
           //This part shows the user location with a blue marker
-          region={this.props.coordinate}
+          region={this.state.region}
           showsUserLocation={true}
           //Initial region specified on the map
-          initialRegion={initialRegion}
+          initialRegion={{
+            latitude: this.state.region.latitude,
+            longitude: this.state.region.longitude,
+            latitudeDelta: this.state.region.latitudeDelta,
+            longitudeDelta: this.state.region.longitudeDelta,
+          }}
         >
         </MapView>
         <Button

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -10,14 +10,6 @@ import {
 import { MapView } from "expo";
 import { Constants, Location, Permissions } from 'expo';
 
-//Set the initial default region of the map to NYC
-initialRegion = {
-  latitude: 40.76727216,
-  longitude: -73.99392888,
-  latitudeDelta: 0.03,
-  longitudeDelta: 0.03,
-}
-
 class HomeScreen extends React.Component {
   constructor(props){
     super(props);
@@ -26,8 +18,8 @@ class HomeScreen extends React.Component {
       region:{
         latitude: 40.76727216,
         longitude: -73.99392888,
-        latitudeDelta: 0.03,
-        longitudeDelta: 0.03,
+        latitudeDelta: 1,
+        longitudeDelta: 1,
       },
       ready: true,
       location: null,
@@ -58,15 +50,14 @@ class HomeScreen extends React.Component {
   }
 
   //Check if the component successfully mounted on DOM
-  componentDidMount() {
-      //init.latitude = pos.coords.latitude;
-    
+  componentDidMount() {    
     //Make an error statement if the mounting has failed
     function errorAlert(err){
       alert(err);
     }
 
     navigator.geolocation.getCurrentPosition (
+      //Get the user position
       (position) => {
         let userState = {
           latitude: position.coords.latitude,
@@ -74,9 +65,8 @@ class HomeScreen extends React.Component {
           latitudeDelta: 0.015,
           longitudeDelta: 0.015
         };
-        //Set the map to the actual user latitude and longitude
+        //Update the map to the actual user latitude and longitude
         this.setState({region:userState});
-        initialRegion = userState
         alert("latitude:" + this.state.region.latitude);
       },
       errorAlert,
@@ -108,7 +98,6 @@ class HomeScreen extends React.Component {
       text = JSON.stringify(this.state.location);
     }
     console.log(text);
-    console.log(this.state.region.latitude)
     return (
       <View style={{flex:1}}>
         <MapView


### PR DESCRIPTION
So far, it seems the react native map renders twice.
This means that at times, the map may first fix to the default page for a second and then move to the actual user location.
This is something we could look at to fix later on.